### PR TITLE
Add healthcare contact scraper foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # vanGrondwelle
-Repo om te werken aan de webscraper voor Jonkheer van Grondwelle
+
+CLI scraper for collecting basic contact details from Dutch healthcare provider websites.
+
+## What it does
+
+The first version crawls a small set of likely contact pages on a provider domain and extracts:
+
+- postal address
+- central phone number
+- central email address
+
+The scraper returns JSON so the output can be piped into other tools later.
+
+## Quick start
+
+```powershell
+python -m venv .venv
+.venv\Scripts\Activate.ps1
+python -m pip install -e .[dev]
+python -m vangrondwelle.cli --pretty ziekenhuis.nl
+```
+
+## Run tests
+
+```powershell
+python -m pytest
+```
+
+## Notes
+
+- The crawler stays on the same domain and only follows a small number of contact-oriented pages.
+- Extraction uses heuristics, so some sites will need future rule tuning.
+- Logs are emitted as JSON on stderr when `--verbose` is enabled.

--- a/changes/2026-03-10-contact-scraper-foundation.md
+++ b/changes/2026-03-10-contact-scraper-foundation.md
@@ -1,0 +1,23 @@
+## What changed
+
+- Added a Python CLI project for scraping Dutch healthcare provider websites.
+- Implemented focused page discovery for contact-oriented pages on the same domain.
+- Added extraction and normalization for address, central phone number, and central email address.
+- Added fixture-based unit tests for extraction and scrape orchestration.
+
+## How to test locally
+
+- Create and activate a virtual environment.
+- Run `python -m pip install -e .[dev]`.
+- Run `python -m pytest`.
+- Try `python -m vangrondwelle.cli --pretty voorbeeldzorg.nl`.
+
+## Risks/rollback
+
+- Extraction is heuristic-based and may miss sites with highly custom markup.
+- Crawling is intentionally shallow and may not reach deeply nested contact pages.
+- Roll back by reverting this branch if the initial project layout is not desired.
+
+## Docs touched
+
+- `README.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vangrondwelle"
+version = "0.1.0"
+description = "CLI scraper for extracting contact details from Dutch healthcare provider websites."
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "beautifulsoup4>=4.12.3,<5.0.0",
+  "requests>=2.32.3,<3.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.3.5,<9.0.0",
+]
+
+[project.scripts]
+vangrondwelle = "vangrondwelle.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/src/vangrondwelle/__init__.py
+++ b/src/vangrondwelle/__init__.py
@@ -1,0 +1,2 @@
+"""vanGrondwelle scraper package."""
+

--- a/src/vangrondwelle/cli.py
+++ b/src/vangrondwelle/cli.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .logging_utils import configure_logging
+from .service import scrape_domain
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vangrondwelle",
+        description="Scrape Dutch healthcare provider websites for basic contact details.",
+    )
+    parser.add_argument(
+        "domains",
+        nargs="+",
+        help="One or more provider domains, for example ziekenhuis.nl or https://www.zorginstelling.nl.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose structured logs on stderr.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+
+    results = [scrape_domain(domain).to_dict() for domain in args.domains]
+    json.dump(results, sys.stdout, indent=2 if args.pretty else None)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/vangrondwelle/crawler.py
+++ b/src/vangrondwelle/crawler.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+LOGGER = logging.getLogger(__name__)
+DISCOVERY_KEYWORDS = (
+    "contact",
+    "bereikbaarheid",
+    "locatie",
+    "locaties",
+    "organisatie",
+    "over-ons",
+)
+
+
+@dataclass(slots=True)
+class CrawledPage:
+    url: str
+    html: str
+
+
+def crawl_contact_pages(
+    domain: str,
+    request_id: str,
+    *,
+    session: requests.Session | None = None,
+    max_pages: int = 8,
+    timeout: int = 12,
+) -> list[CrawledPage]:
+    client = session or requests.Session()
+    start_url = f"https://{domain}"
+    queue = deque([start_url])
+    visited: set[str] = set()
+    pages: list[CrawledPage] = []
+
+    while queue and len(visited) < max_pages:
+        url = queue.popleft()
+        if url in visited:
+            continue
+        visited.add(url)
+        response = _fetch_url(client, url, request_id, domain, timeout)
+        if response is None:
+            continue
+
+        pages.append(CrawledPage(url=url, html=response.text))
+        for next_url in _discover_contact_links(response.text, url, domain):
+            if next_url not in visited and next_url not in queue and len(visited) + len(queue) < max_pages:
+                queue.append(next_url)
+
+    return pages
+
+
+def _fetch_url(
+    session: requests.Session,
+    url: str,
+    request_id: str,
+    domain: str,
+    timeout: int,
+) -> requests.Response | None:
+    LOGGER.info(
+        "Fetching candidate page.",
+        extra={"request_id": request_id, "domain": domain, "url": url},
+    )
+    try:
+        response = session.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": "vanGrondwelle/0.1 (+https://github.com/racejames/vanGrondwelle)"},
+        )
+        LOGGER.info(
+            "Fetched page response.",
+            extra={
+                "request_id": request_id,
+                "domain": domain,
+                "url": url,
+                "status_code": response.status_code,
+            },
+        )
+        if response.status_code >= 400:
+            return None
+        if "text/html" not in response.headers.get("Content-Type", ""):
+            return None
+        return response
+    except requests.RequestException:
+        LOGGER.exception(
+            "Failed to fetch page.",
+            extra={"request_id": request_id, "domain": domain, "url": url},
+        )
+        return None
+
+
+def _discover_contact_links(html: str, base_url: str, domain: str) -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    matches: list[str] = []
+    for anchor in soup.find_all("a", href=True):
+        href = anchor["href"].strip()
+        text = anchor.get_text(" ", strip=True).lower()
+        target = href.lower()
+        if not any(keyword in f"{text} {target}" for keyword in DISCOVERY_KEYWORDS):
+            continue
+        absolute = urljoin(base_url, href)
+        parsed = urlparse(absolute)
+        if parsed.netloc and parsed.netloc.lower().removeprefix("www.") != domain:
+            continue
+        matches.append(absolute.split("#", 1)[0])
+    return list(dict.fromkeys(matches))

--- a/src/vangrondwelle/extractor.py
+++ b/src/vangrondwelle/extractor.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from bs4 import BeautifulSoup
+
+from .models import ContactInfo
+from .normalize import normalize_email, normalize_phone, normalize_text
+
+EMAIL_RE = re.compile(r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[A-Za-z]{2,}\b")
+PHONE_RE = re.compile(r"(?:(?:\+31|0031|0)\s*(?:\(0\)\s*)?(?:[\d\s\-()]){8,}\d)")
+POSTCODE_RE = re.compile(r"\b\d{4}\s?[A-Z]{2}\b")
+ADDRESS_HINTS = (
+    "straat",
+    "laan",
+    "plein",
+    "weg",
+    "gracht",
+    "hof",
+    "postbus",
+)
+PHONE_LABELS = ("telefoon", "tel", "bel", "contact")
+EMAIL_LABELS = ("mail", "e-mail", "email", "contact")
+
+
+def extract_contact_info(html: str, domain: str, source_url: str) -> ContactInfo:
+    soup = BeautifulSoup(html, "html.parser")
+    text_chunks = list(_iter_text_chunks(soup))
+    addresses = _find_addresses(text_chunks)
+    phones = _find_phones(soup, text_chunks)
+    emails = _find_emails(soup, text_chunks, domain)
+
+    notes: list[str] = []
+    if not addresses:
+        notes.append("No postal address detected.")
+    if not phones:
+        notes.append("No central phone number detected.")
+    if not emails:
+        notes.append("No central email address detected.")
+
+    confidence = 0.0
+    confidence += 0.4 if addresses else 0.0
+    confidence += 0.3 if phones else 0.0
+    confidence += 0.3 if emails else 0.0
+
+    return ContactInfo(
+        domain=domain,
+        source_url=source_url,
+        address=addresses[0] if addresses else None,
+        phone=phones[0] if phones else None,
+        email=emails[0] if emails else None,
+        confidence=confidence,
+        notes=notes,
+    )
+
+
+def _iter_text_chunks(soup: BeautifulSoup) -> Iterable[str]:
+    for node in soup.find_all(["p", "li", "div", "span", "address"]):
+        text = normalize_text(node.get_text(" ", strip=True))
+        if text:
+            yield text
+
+
+def _find_addresses(chunks: list[str]) -> list[str]:
+    matches: list[str] = []
+    for chunk in chunks:
+        if not POSTCODE_RE.search(chunk):
+            continue
+        candidate = normalize_text(chunk)
+        if not candidate:
+            continue
+        lowered = candidate.lower()
+        if any(hint in lowered for hint in ADDRESS_HINTS) or "postbus" in lowered:
+            matches.append(candidate)
+        elif re.search(r"\b\d{1,4}[a-zA-Z]?\b", candidate):
+            matches.append(candidate)
+    return _dedupe(matches)
+
+
+def _find_phones(soup: BeautifulSoup, chunks: list[str]) -> list[str]:
+    matches: list[str] = []
+    for anchor in soup.find_all("a", href=True):
+        href = anchor["href"].strip()
+        if href.startswith("tel:"):
+            normalized = normalize_phone(href.removeprefix("tel:"))
+            if normalized and not normalized.startswith("06"):
+                matches.append(normalized)
+
+    for chunk in chunks:
+        lowered = chunk.lower()
+        if not any(label in lowered for label in PHONE_LABELS):
+            continue
+        for candidate in PHONE_RE.findall(chunk):
+            normalized = normalize_phone(candidate)
+            if normalized:
+                matches.append(normalized)
+
+    return _dedupe(_rank_phones(matches))
+
+
+def _find_emails(soup: BeautifulSoup, chunks: list[str], domain: str) -> list[str]:
+    matches: list[str] = []
+    domain_suffix = domain.lower()
+    for anchor in soup.find_all("a", href=True):
+        href = anchor["href"].strip()
+        if href.startswith("mailto:"):
+            email = normalize_email(href.removeprefix("mailto:").split("?")[0])
+            if email:
+                matches.append(email)
+
+    for chunk in chunks:
+        lowered = chunk.lower()
+        if not any(label in lowered for label in EMAIL_LABELS):
+            continue
+        for candidate in EMAIL_RE.findall(chunk):
+            matches.append(candidate)
+
+    ranked = []
+    for email in _dedupe(matches):
+        if domain_suffix and not email.endswith(domain_suffix):
+            continue
+        if any(token in email for token in ("noreply", "no-reply", "privacy", "factuur")):
+            continue
+        ranked.append(email)
+    return ranked
+
+
+def _rank_phones(values: list[str]) -> list[str]:
+    def score(value: str) -> tuple[int, int]:
+        central_bonus = 1 if value.startswith(("0800", "0900", "+31", "0")) else 0
+        mobile_penalty = -1 if value.startswith("06") else 0
+        return (central_bonus + mobile_penalty, -len(value))
+
+    return sorted(values, key=score, reverse=True)
+
+
+def _dedupe(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for value in values:
+        normalized = normalize_text(value)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        output.append(normalized)
+    return output

--- a/src/vangrondwelle/logging_utils.py
+++ b/src/vangrondwelle/logging_utils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from datetime import UTC, datetime
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "timestamp": datetime.now(UTC).isoformat(),
+            "level": record.levelname.lower(),
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, "request_id"):
+            payload["request_id"] = record.request_id
+        if hasattr(record, "domain"):
+            payload["domain"] = record.domain
+        if hasattr(record, "url"):
+            payload["url"] = record.url
+        if hasattr(record, "status_code"):
+            payload["status_code"] = record.status_code
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        return json.dumps(payload, ensure_ascii=True)
+
+
+def configure_logging(verbose: bool) -> None:
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(JsonFormatter())
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.DEBUG if verbose else logging.INFO)

--- a/src/vangrondwelle/models.py
+++ b/src/vangrondwelle/models.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass(slots=True)
+class ContactInfo:
+    domain: str
+    source_url: str | None = None
+    address: str | None = None
+    phone: str | None = None
+    email: str | None = None
+    confidence: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+

--- a/src/vangrondwelle/normalize.py
+++ b/src/vangrondwelle/normalize.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import urlparse
+
+WHITESPACE_RE = re.compile(r"\s+")
+PHONE_CLEAN_RE = re.compile(r"[^\d+]")
+
+
+def normalize_domain(value: str) -> str:
+    candidate = value.strip()
+    if not candidate:
+        return ""
+
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+
+    parsed = urlparse(candidate)
+    host = parsed.netloc or parsed.path
+    return host.lower().removeprefix("www.")
+
+
+def normalize_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = WHITESPACE_RE.sub(" ", value).strip(" ,;\n\t")
+    return cleaned or None
+
+
+def normalize_phone(value: str | None) -> str | None:
+    text = normalize_text(value)
+    if not text:
+        return None
+
+    compact = PHONE_CLEAN_RE.sub("", text)
+    compact = compact.replace("0031", "+31")
+    if compact.startswith("31") and not compact.startswith("+31"):
+        compact = f"+{compact}"
+    if compact.startswith("06"):
+        return None
+    if compact.startswith("0800") or compact.startswith("0900"):
+        return compact
+    if compact.startswith("0"):
+        return compact
+    if compact.startswith("+31"):
+        return compact
+    return text
+
+
+def normalize_email(value: str | None) -> str | None:
+    text = normalize_text(value)
+    if not text:
+        return None
+    return text.lower()

--- a/src/vangrondwelle/service.py
+++ b/src/vangrondwelle/service.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import logging
+from uuid import uuid4
+
+from .crawler import crawl_contact_pages
+from .extractor import extract_contact_info
+from .models import ContactInfo
+from .normalize import normalize_domain
+
+LOGGER = logging.getLogger(__name__)
+
+
+def scrape_domain(domain_input: str) -> ContactInfo:
+    domain = normalize_domain(domain_input)
+    request_id = str(uuid4())
+    LOGGER.info(
+        "Starting scrape request.",
+        extra={"request_id": request_id, "domain": domain},
+    )
+
+    best_match = ContactInfo(domain=domain, notes=["No HTML pages were fetched."])
+    pages = crawl_contact_pages(domain, request_id)
+    for page in pages:
+        candidate = extract_contact_info(page.html, domain, page.url)
+        if candidate.confidence > best_match.confidence:
+            best_match = candidate
+
+    LOGGER.info(
+        "Finished scrape request.",
+        extra={
+            "request_id": request_id,
+            "domain": domain,
+            "url": best_match.source_url,
+        },
+    )
+    return best_match

--- a/tests/fixtures/contact_page.html
+++ b/tests/fixtures/contact_page.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <body>
+    <main>
+      <h1>Contact</h1>
+      <p>Voor algemene vragen kunt u contact opnemen met onze centrale receptie.</p>
+      <address>
+        Jonkheer van Grondwelle Zorg
+        Dorpsstraat 12
+        1234 AB Amsterdam
+      </address>
+      <p>Telefoon: 020 - 123 45 67</p>
+      <p>E-mail: <a href="mailto:info@voorbeeldzorg.nl">info@voorbeeldzorg.nl</a></p>
+    </main>
+  </body>
+</html>

--- a/tests/fixtures/home_page.html
+++ b/tests/fixtures/home_page.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="nl">
+  <body>
+    <nav>
+      <a href="/contact">Contact</a>
+      <a href="/locaties">Locaties</a>
+    </nav>
+  </body>
+</html>

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from vangrondwelle.extractor import extract_contact_info
+
+
+def read_fixture(name: str) -> str:
+    return Path(__file__).parent.joinpath("fixtures", name).read_text(encoding="utf-8")
+
+
+def test_extract_contact_info_returns_address_phone_and_email() -> None:
+    html = read_fixture("contact_page.html")
+
+    result = extract_contact_info(
+        html,
+        domain="voorbeeldzorg.nl",
+        source_url="https://voorbeeldzorg.nl/contact",
+    )
+
+    assert result.address is not None
+    assert "Dorpsstraat 12" in result.address
+    assert result.phone == "0201234567"
+    assert result.email == "info@voorbeeldzorg.nl"
+    assert result.confidence == 1.0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from vangrondwelle import service
+from vangrondwelle.crawler import CrawledPage
+
+
+def read_fixture(name: str) -> str:
+    return Path(__file__).parent.joinpath("fixtures", name).read_text(encoding="utf-8")
+
+
+def test_scrape_domain_returns_best_contact_page(monkeypatch) -> None:
+    home_page = read_fixture("home_page.html")
+    contact_page = read_fixture("contact_page.html")
+
+    def fake_crawl_contact_pages(domain: str, request_id: str) -> list[CrawledPage]:
+        assert domain == "voorbeeldzorg.nl"
+        assert request_id
+        return [
+            CrawledPage(url="https://voorbeeldzorg.nl", html=home_page),
+            CrawledPage(url="https://voorbeeldzorg.nl/contact", html=contact_page),
+        ]
+
+    monkeypatch.setattr(service, "crawl_contact_pages", fake_crawl_contact_pages)
+
+    result = service.scrape_domain("https://www.voorbeeldzorg.nl")
+
+    assert result.source_url == "https://voorbeeldzorg.nl/contact"
+    assert result.phone == "0201234567"
+    assert result.email == "info@voorbeeldzorg.nl"


### PR DESCRIPTION
## What changed

- Added a Python CLI scraper that crawls likely contact pages on Dutch healthcare provider domains.
- Added extraction and normalization for postal address, central phone number, and central email address.
- Added structured JSON logging, fixture-based tests, and a change note for the initial foundation.

## How to test locally

- `python -m pip install -e .[dev]`
- `python -m pytest`
- `python -m vangrondwelle.cli --pretty voorbeeldzorg.nl`

## Risks/rollback

- Extraction is heuristic-based and will need tuning for websites with unusual markup.
- Crawling is intentionally shallow, so some nested contact pages may be missed.
- Roll back by reverting commit `e406ebf` if needed.

## Docs touched

- `README.md`
- `changes/2026-03-10-contact-scraper-foundation.md`

Fixes #1
